### PR TITLE
Remove hardcoded image style

### DIFF
--- a/computedfont/plugin.js
+++ b/computedfont/plugin.js
@@ -106,7 +106,7 @@
 					var preview;
 
 					if (previews !== undefined && previews[ name ] !== undefined) {
-						preview = "<img src='" + previews[ name ] + "' style='padding: 0; margin: 0; margin-bottom: -4px; outline: none;' />";
+						preview = "<img src='" + previews[ name ] + "' />";
 					} else {
 						preview = styles[ name ].buildPreview();
 					}


### PR DESCRIPTION
We can style the images with `.cke_panel_listItem a > img`. So we should remove hard-coded style.